### PR TITLE
registry: add Moonshine Tiny EN model

### DIFF
--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -40,5 +40,7 @@
   "model.sherpa-onnx.streaming-zipformer-en-20m-2023-02-17.title": "Streaming Zipformer EN",
   "model.sherpa-onnx.streaming-zipformer-en-20m-2023-02-17.description": "Compact English streaming Zipformer model for local realtime recognition.",
   "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.title": "Streaming Zipformer ZH",
-  "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.description": "Chinese streaming Zipformer model for local realtime recognition."
+  "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.description": "Chinese streaming Zipformer model for local realtime recognition.",
+  "model.sherpa-onnx.moonshine-tiny-en-int8.title": "Moonshine Tiny (EN)",
+  "model.sherpa-onnx.moonshine-tiny-en-int8.description": "Compact offline English Moonshine model packaged for sherpa-onnx."
 }

--- a/i18n/zh_CN.json
+++ b/i18n/zh_CN.json
@@ -40,5 +40,7 @@
   "model.sherpa-onnx.streaming-zipformer-en-20m-2023-02-17.title": "流式 Zipformer 英文",
   "model.sherpa-onnx.streaming-zipformer-en-20m-2023-02-17.description": "Zipformer 英文流式模型，体积较小，适合本地实时识别。",
   "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.title": "流式 Zipformer 中文",
-  "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.description": "Zipformer 中文流式模型，适合本地实时中文识别。"
+  "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.description": "Zipformer 中文流式模型，适合本地实时中文识别。",
+  "model.sherpa-onnx.moonshine-tiny-en-int8.title": "Moonshine Tiny（英文）",
+  "model.sherpa-onnx.moonshine-tiny-en-int8.description": "适配 sherpa-onnx 的 Moonshine 英文离线语音识别模型，体积较小。"
 }

--- a/registry/models.json
+++ b/registry/models.json
@@ -628,6 +628,63 @@
           }
         }
       }
+    },
+    {
+      "id": "model.sherpa-onnx.moonshine-tiny-en-int8",
+      "short_id": "onnx-moonshine-tiny-en-int8-off",
+      "urls": [
+        "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-tiny-en-int8.tar.bz2",
+        "https://gh-proxy.com/https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-tiny-en-int8.tar.bz2",
+        "https://ghfast.top/https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-tiny-en-int8.tar.bz2"
+      ],
+      "sha256": "d5fe6ec4334fef36255b2a4010412cad4c007e33103fec62fb5d17cad88086f2",
+      "size_bytes": 107600538,
+      "language": "en",
+      "vinput_model": {
+        "backend": "sherpa-offline",
+        "language": "en",
+        "size_bytes": 107600538,
+        "supports_hotwords": false,
+        "runtime": "offline",
+        "family": "moonshine",
+        "recognizer": {
+          "feat_config": {
+            "sample_rate": 16000,
+            "feature_dim": 80
+          },
+          "lm_config": {
+            "model": "",
+            "scale": 0.0
+          },
+          "decoding_method": "greedy_search",
+          "max_active_paths": 4,
+          "hotwords_file": "",
+          "hotwords_score": 1.5,
+          "rule_fsts": "",
+          "rule_fars": "",
+          "blank_penalty": 0.0,
+          "hr": {
+            "lexicon": "",
+            "rule_fsts": ""
+          }
+        },
+        "model": {
+          "tokens": "tokens.txt",
+          "num_threads": 1,
+          "debug": 0,
+          "provider": "cpu",
+          "model_type": "",
+          "modeling_unit": "",
+          "bpe_vocab": "",
+          "telespeech_ctc": "",
+          "moonshine": {
+            "preprocessor": "preprocess.onnx",
+            "encoder": "encode.int8.onnx",
+            "uncached_decoder": "uncached_decode.int8.onnx",
+            "cached_decoder": "cached_decode.int8.onnx"
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

* add a Moonshine Tiny English model entry to the registry
* add English and Chinese i18n strings
* wire the registry metadata to the Moonshine local model layout used by fcitx5-vinput

## Included

* `registry/models.json`
* `i18n/en_US.json`
* `i18n/zh_CN.json`

## Model

* short id: `onnx-moonshine-tiny-en-int8-off`
* family: `moonshine`
* runtime: `offline`
* backend: `sherpa-offline`

## Archive

* size: `107600538`
* sha256: `d5fe6ec4334fef36255b2a4010412cad4c007e33103fec62fb5d17cad88086f2`
