### PR TITLE
Add Moonshine Base EN int8 model

### DIFF
--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -42,5 +42,7 @@
   "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.title": "Streaming Zipformer ZH",
   "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.description": "Chinese streaming Zipformer model for local realtime recognition.",
   "model.sherpa-onnx.moonshine-tiny-en-int8.title": "Moonshine Tiny EN",
-  "model.sherpa-onnx.moonshine-tiny-en-int8.description": "Compact English Moonshine model for offline local speech recognition."
+  "model.sherpa-onnx.moonshine-tiny-en-int8.description": "Compact English Moonshine model for offline local speech recognition.",
+  "model.sherpa-onnx.moonshine-base-en-int8.title": "Moonshine Base EN",
+  "model.sherpa-onnx.moonshine-base-en-int8.description": "Larger English Moonshine model for offline local speech recognition."
 }

--- a/i18n/zh_CN.json
+++ b/i18n/zh_CN.json
@@ -42,5 +42,7 @@
   "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.title": "流式 Zipformer 中文",
   "model.sherpa-onnx.streaming-zipformer-zh-int8-2025-06-30.description": "Zipformer 中文流式模型，适合本地实时中文识别。",
   "model.sherpa-onnx.moonshine-tiny-en-int8.title": "Moonshine Tiny 英文",
-  "model.sherpa-onnx.moonshine-tiny-en-int8.description": "Moonshine Tiny 英文离线模型，适合本地语音识别。"
+  "model.sherpa-onnx.moonshine-tiny-en-int8.description": "Moonshine Tiny 英文离线模型，适合本地语音识别。",
+  "model.sherpa-onnx.moonshine-base-en-int8.title": "Moonshine Base 英文",
+  "model.sherpa-onnx.moonshine-base-en-int8.description": "Moonshine Base 英文离线模型，适合更高准确度的本地语音识别。"
 }

--- a/registry/models.json
+++ b/registry/models.json
@@ -685,6 +685,63 @@
           }
         }
       }
+    },
+    {
+      "id": "model.sherpa-onnx.moonshine-base-en-int8",
+      "short_id": "onnx-ms-base-en-int8-off",
+      "urls": [
+        "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-en-int8.tar.bz2",
+        "https://gh-proxy.com/https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-en-int8.tar.bz2",
+        "https://ghfast.top/https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-en-int8.tar.bz2"
+      ],
+      "sha256": "21870cecaa2e44e4e2bf63e02d1072bed183ccd10284871353bd9d24dad14e5e",
+      "size_bytes": 250807309,
+      "language": "en",
+      "vinput_model": {
+        "backend": "sherpa-offline",
+        "language": "en",
+        "size_bytes": 250807309,
+        "supports_hotwords": false,
+        "runtime": "offline",
+        "family": "moonshine",
+        "recognizer": {
+          "feat_config": {
+            "sample_rate": 16000,
+            "feature_dim": 80
+          },
+          "lm_config": {
+            "model": "",
+            "scale": 0.0
+          },
+          "decoding_method": "greedy_search",
+          "max_active_paths": 4,
+          "hotwords_file": "",
+          "hotwords_score": 1.5,
+          "rule_fsts": "",
+          "rule_fars": "",
+          "blank_penalty": 0.0,
+          "hr": {
+            "lexicon": "",
+            "rule_fsts": ""
+          }
+        },
+        "model": {
+          "tokens": "tokens.txt",
+          "num_threads": 1,
+          "debug": 0,
+          "provider": "cpu",
+          "model_type": "",
+          "modeling_unit": "",
+          "bpe_vocab": "",
+          "telespeech_ctc": "",
+          "moonshine": {
+            "preprocessor": "preprocess.onnx",
+            "encoder": "encode.int8.onnx",
+            "uncached_decoder": "uncached_decode.int8.onnx",
+            "cached_decoder": "cached_decode.int8.onnx"
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds the `sherpa-onnx-moonshine-base-en-int8` offline English model to the Vinput registry.

Tested locally with fcitx5-vinput 2.2.1 on Kubuntu 26.04 using a local registry server.

Model archive:
- URL: https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-moonshine-base-en-int8.tar.bz2
- SHA256: 21870cecaa2e44e4e2bf63e02d1072bed183ccd10284871353bd9d24dad14e5e
- Size: 250807309 bytes

Archive layout verified:
- preprocess.onnx
- encode.int8.onnx
- uncached_decode.int8.onnx
- cached_decode.int8.onnx
- tokens.txt

Vinput test result:
- model listed from local registry
- model downloaded and activated
- daemon restarted successfully
- recognition worked with: “This is a test of moonshine base model.”

This is registry-only; no fcitx5-vinput app code changes are needed because Moonshine already works through the existing `sherpa-offline` runtime path.
