### PR TITLE
fix(openai-compatible): split realtime session model

### DIFF
--- a/registry/providers.json
+++ b/registry/providers.json
@@ -254,6 +254,10 @@
         {
           "name": "VINPUT_ASR_MODEL",
           "required": false
+        },
+        {
+          "name": "VINPUT_ASR_SESSION_MODEL",
+          "required": false
         }
       ]
     }

--- a/resources/providers/openai-compatible/streaming/README.md
+++ b/resources/providers/openai-compatible/streaming/README.md
@@ -39,7 +39,9 @@ explicitly sets `sample_rate`.
 - `VINPUT_ASR_URL` optional
   Full realtime websocket URL. Overrides the default endpoint.
 - `VINPUT_ASR_MODEL` optional
-  Realtime transcription model id.
+  Transcription model id forwarded as `audio.input.transcription.model`.
+- `VINPUT_ASR_SESSION_MODEL` optional
+  Realtime websocket `model`. Defaults to `VINPUT_ASR_MODEL`.
 - `VINPUT_ASR_LANGUAGE` optional
   Language hint forwarded to the upstream transcription session.
 - `VINPUT_ASR_PROMPT` optional
@@ -69,3 +71,5 @@ explicitly sets `sample_rate`.
 - The script uses OpenAI-style realtime transcription events such as `session.update`,
   `input_audio_buffer.append`, `conversation.item.input_audio_transcription.delta`,
   and `conversation.item.input_audio_transcription.completed`.
+- For OpenAI official Realtime transcription, use `VINPUT_ASR_SESSION_MODEL=gpt-realtime`,
+  `VINPUT_ASR_MODEL=gpt-realtime-whisper`, and set `VINPUT_ASR_FINISH_GRACE_SECS=2`.

--- a/resources/providers/openai-compatible/streaming/entry.py
+++ b/resources/providers/openai-compatible/streaming/entry.py
@@ -343,7 +343,7 @@ class WebSocketClient:
         return data
 
 
-def build_url(model: str) -> str:
+def build_url(session_model: str) -> str:
     explicit_url = get_optional_env("VINPUT_ASR_URL")
     if explicit_url:
         base_url = explicit_url
@@ -362,13 +362,15 @@ def build_url(model: str) -> str:
 
     parsed = urlparse(base_url)
     query = dict(parse_qsl(parsed.query, keep_blank_values=True))
-    query.setdefault("model", model)
+    query.setdefault("model", session_model)
     return urlunparse(parsed._replace(query=urlencode(query)))
 
 
-def build_session_update_event(model: str, target_sample_rate: int) -> Dict[str, Any]:
+def build_session_update_event(
+    transcription_model: str, target_sample_rate: int, session_type: str
+) -> Dict[str, Any]:
     session: Dict[str, Any] = {
-        "type": "transcription",
+        "type": session_type,
         "audio": {
             "input": {
                 "format": {
@@ -376,7 +378,7 @@ def build_session_update_event(model: str, target_sample_rate: int) -> Dict[str,
                     "rate": target_sample_rate,
                 },
                 "transcription": {
-                    "model": model,
+                    "model": transcription_model,
                 },
             }
         },
@@ -488,7 +490,9 @@ def handle_server_message(message: Dict[str, Any], state: Dict[str, Any]) -> Non
 
 def run() -> int:
     api_key = get_required_env("VINPUT_ASR_API_KEY")
-    model = get_optional_env("VINPUT_ASR_MODEL", DEFAULT_MODEL)
+    transcription_model = get_optional_env("VINPUT_ASR_MODEL", DEFAULT_MODEL)
+    session_model = get_optional_env("VINPUT_ASR_SESSION_MODEL", transcription_model)
+    session_type = "realtime" if session_model != transcription_model else "transcription"
     timeout = get_optional_int_env("VINPUT_ASR_TIMEOUT", DEFAULT_TIMEOUT)
     finish_grace_secs = get_optional_float_env(
         "VINPUT_ASR_FINISH_GRACE_SECS", DEFAULT_FINISH_GRACE_SECS
@@ -496,11 +500,13 @@ def run() -> int:
     target_sample_rate = get_optional_int_env(
         "VINPUT_ASR_TARGET_SAMPLE_RATE", DEFAULT_TARGET_SAMPLE_RATE
     )
-    url = build_url(model)
+    url = build_url(session_model)
 
     headers = {"Authorization": f"Bearer {api_key}"}
     client = WebSocketClient(url, headers, timeout)
-    client.send_json(build_session_update_event(model, target_sample_rate))
+    client.send_json(
+        build_session_update_event(transcription_model, target_sample_rate, session_type)
+    )
 
     state: Dict[str, Any] = {
         "session_started": False,


### PR DESCRIPTION
## Problem

OpenAI's official Realtime transcription API requires two separate models:
- The WebSocket realtime session uses a realtime model, for example `gpt-realtime`
- The audio transcription config `audio.input.transcription.model` uses a transcription model, for example `gpt-realtime-whisper`

The current `openai-compatible` streaming provider only uses one variable, `VINPUT_ASR_MODEL`, and passes it to both the WebSocket URL `model` parameter and `audio.input.transcription.model`.

When users set `VINPUT_ASR_MODEL=gpt-realtime-whisper` and connect to OpenAI's official Realtime API, the server returns an error because gpt-realtime-whisper cannot be used as the realtime session model.


## Changes
- Add `VINPUT_ASR_SESSION_MODEL` for the WebSocket URL model parameter.
- Keep `VINPUT_ASR_MODEL` as audio.input.transcription.model.
- Automatically use a realtime session update when the session model differs from the transcription model.
- Update the registry env list and the OpenAI official configuration example in README.

## Compatibility
This change is compatible with the previous usage.
If `VINPUT_ASR_SESSION_MODEL` is not set, the script continues to use `VINPUT_ASR_MODEL` as the WebSocket URL model parameter, so existing single-model configurations do not need any changes.

For example, this existing configuration still works:
```env
VINPUT_ASR_MODEL=some-openai-compatible-model
```
`VINPUT_ASR_SESSION_MODEL` only needs to be set when connecting to OpenAI's official Realtime transcription API and separating the session model from the transcription model is required.

## OpenAI Official Example Configuration
```env
VINPUT_ASR_SESSION_MODEL=gpt-realtime
VINPUT_ASR_MODEL=gpt-realtime-whisper
VINPUT_ASR_FINISH_GRACE_SECS=2
```