### PR TITLE
feat(provider): add ElevenLabs no_verbatim option

### DIFF
--- a/registry/providers.json
+++ b/registry/providers.json
@@ -50,6 +50,10 @@
         {
           "name": "VINPUT_ASR_LANGUAGE",
           "required": false
+        },
+        {
+          "name": "VINPUT_ASR_ELEVENLABS_NO_VERBATIM",
+          "required": false
         }
       ]
     },
@@ -75,6 +79,10 @@
         },
         {
           "name": "VINPUT_ASR_LANGUAGE",
+          "required": false
+        },
+        {
+          "name": "VINPUT_ASR_ELEVENLABS_NO_VERBATIM",
           "required": false
         }
       ]

--- a/resources/providers/elevenlabs/batch/README.md
+++ b/resources/providers/elevenlabs/batch/README.md
@@ -18,6 +18,10 @@ Cloud ASR provider script for the ElevenLabs speech-to-text API.
 - `VINPUT_ASR_MODEL` optional
 - `VINPUT_ASR_LANGUAGE` optional
 - `VINPUT_ASR_URL` optional
+- `VINPUT_ASR_ELEVENLABS_NO_VERBATIM` optional
+  Set to `true` to ask ElevenLabs to remove filler words, false starts,
+  non-speech sounds, and disfluencies. Supported by ElevenLabs Scribe v2
+  models. Defaults to `false`.
 - `VINPUT_ASR_TIMEOUT` optional
 
 ## Notes

--- a/resources/providers/elevenlabs/batch/entry.py
+++ b/resources/providers/elevenlabs/batch/entry.py
@@ -37,7 +37,7 @@ def get_optional_int_env(name: str, default: int) -> int:
 
 def get_optional_bool_env(name: str, default: bool) -> bool:
     value = os.getenv(name)
-    if value is None:
+    if value is None or not value.strip():
         return default
     return value.strip().lower() not in {"0", "false", "no", "off"}
 
@@ -113,6 +113,7 @@ def transcribe(
     endpoint: str,
     enable_logging: bool,
     tag_audio_events: bool,
+    no_verbatim: bool,
 ) -> str:
     query = urlencode({"enable_logging": str(enable_logging).lower()})
     url = endpoint
@@ -123,6 +124,7 @@ def transcribe(
         ("model_id", model_id),
         ("file_format", "pcm_s16le_16"),
         ("tag_audio_events", str(tag_audio_events).lower()),
+        ("no_verbatim", str(no_verbatim).lower()),
     ]
     if language_code:
         fields.append(("language_code", language_code))
@@ -163,6 +165,9 @@ def main() -> int:
         tag_audio_events = get_optional_bool_env(
             "VINPUT_ASR_TAG_AUDIO_EVENTS", False
         )
+        no_verbatim = get_optional_bool_env(
+            "VINPUT_ASR_ELEVENLABS_NO_VERBATIM", False
+        )
         pcm_audio = read_audio_input()
 
         text = transcribe(
@@ -174,6 +179,7 @@ def main() -> int:
             endpoint=endpoint,
             enable_logging=enable_logging,
             tag_audio_events=tag_audio_events,
+            no_verbatim=no_verbatim,
         )
     except ValueError as exc:
         print(str(exc), file=sys.stderr)

--- a/resources/providers/elevenlabs/streaming/README.md
+++ b/resources/providers/elevenlabs/streaming/README.md
@@ -49,6 +49,10 @@ Normalized transcript semantics used by this script:
 - `VINPUT_ASR_INCLUDE_TIMESTAMPS` optional
 - `VINPUT_ASR_INCLUDE_LANGUAGE_DETECTION` optional
 - `VINPUT_ASR_COMMIT_STRATEGY` optional
+- `VINPUT_ASR_ELEVENLABS_NO_VERBATIM` optional
+  Set to `true` to ask ElevenLabs to remove filler words, false starts,
+  non-speech sounds, and disfluencies. Supported by ElevenLabs Scribe v2
+  models. Defaults to `false`.
 - `VINPUT_ASR_VAD_SILENCE_THRESHOLD_SECS` optional
 - `VINPUT_ASR_VAD_THRESHOLD` optional
 - `VINPUT_ASR_MIN_SPEECH_DURATION_MS` optional

--- a/resources/providers/elevenlabs/streaming/entry.py
+++ b/resources/providers/elevenlabs/streaming/entry.py
@@ -81,7 +81,7 @@ def get_optional_float_env(name: str, default: float) -> float:
 
 def get_optional_bool_env(name: str, default: bool) -> bool:
     value = os.getenv(name)
-    if value is None:
+    if value is None or not value.strip():
         return default
     return value.strip().lower() not in {"0", "false", "no", "off"}
 
@@ -367,6 +367,9 @@ def build_url() -> str:
         ).lower(),
         "audio_format": get_optional_env("VINPUT_ASR_AUDIO_FORMAT", "pcm_16000"),
         "commit_strategy": get_optional_env("VINPUT_ASR_COMMIT_STRATEGY", "manual"),
+        "no_verbatim": str(
+            get_optional_bool_env("VINPUT_ASR_ELEVENLABS_NO_VERBATIM", False)
+        ).lower(),
         "enable_logging": str(
             get_optional_bool_env("VINPUT_ASR_ENABLE_LOGGING", True)
         ).lower(),


### PR DESCRIPTION
## Summary

Add an ElevenLabs-specific environment variable to enable `no_verbatim` transcription.

## Changes

- Add `VINPUT_ASR_ELEVENLABS_NO_VERBATIM` to ElevenLabs batch and streaming providers.
- Map it to ElevenLabs `no_verbatim` API parameter.
- Keep default behavior unchanged with default `false`.
- Treat empty env values as default.
- Document Scribe v2 support requirement.

## Reference

ElevenLabs documents `no_verbatim` as removing filler words, false starts, and non-speech sounds:

- [Realtime Speech-to-Text API](https://elevenlabs.io/docs/api-reference/speech-to-text/v-1-speech-to-text-realtime)
- [Batch Speech-to-Text API](https://elevenlabs.io/docs/api-reference/speech-to-text/convert)