### PR TITLE
修复豆包输入法丢失语音开头 1~2 秒音频的问题

### DIFF
--- a/resources/providers/doubaoime/streaming/entry.py
+++ b/resources/providers/doubaoime/streaming/entry.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import json
 import os
+import queue
 import secrets
 import socket
 import ssl
@@ -1071,6 +1072,16 @@ def send_audio_frame(
 
 
 def run() -> int:
+    # Use a separate thread to read stdin lines to avoid blocking the vinput-daemon event loop, 
+    # which could cause first several seconds of audio to be dropped.
+    input_queue: queue.Queue = queue.Queue()
+    def read_stdin() -> None:
+        try:
+            for raw_line in sys.stdin:
+                input_queue.put(raw_line)
+        finally:
+            input_queue.put(None)
+    threading.Thread(target=read_stdin, daemon=True).start()
     timeout = get_optional_int_env("VINPUT_ASR_TIMEOUT", DEFAULT_TIMEOUT)
     finish_grace_secs = get_optional_float_env(
         "VINPUT_ASR_FINISH_GRACE_SECS", DEFAULT_FINISH_GRACE_SECS
@@ -1126,6 +1137,7 @@ def run() -> int:
                 write_stderr(f"Doubao IME terminal exception ignored after final result: {exc}")
         finally:
             stop_event.set()
+            input_queue.put(None)
 
     thread = threading.Thread(target=reader, daemon=True)
     thread.start()
@@ -1172,7 +1184,7 @@ def run() -> int:
         finish_requested = True
 
     try:
-        for raw_line in sys.stdin:
+        for raw_line in iter(input_queue.get, None):
             if stop_event.is_set():
                 break
 


### PR DESCRIPTION
# 1. 问题描述

如题。当使用 Doubao IME ASR Provider 时，按下语音快捷键后立刻说话，则语音的前一两秒内容会丢失。

例如说「今天真是个好天气」，只能识别到「天真是个好天气」「真是个好天气」，甚至只有「好天气」。

# 2. 原因

目前的逻辑在开始运行之后，provider 会在主线程上执行 Health Check，这会阻塞住主线程而不去立刻开始读取 stdin，从而间接阻塞住 `vinput-daemon` 向 stdin push 音频的线程（很不幸，也是 daemon 的主线程），从而阻塞住新音频输入的接收。因此在 health check 完成之前，所有的音频输入都会丢失。

最根本的解决方法应该是在 daemon 侧将 push audio 的任务 offload 到非主线程上。不过最简单的解决方法是在 provider 这一侧积极消费 stdin，从而不阻塞主线程。

# 3. 解决方案

本 PR 就是实现了这样一个简单的输入缓冲，在 provider 启动时立刻开始消费 stdin，而不等到 health check 阻塞完成。后续从缓冲区中获取输入内容。

经过检验，已经可以确定修复该问题。