### PR TITLE
豆包输入法接口的稳定性修复

### DIFF
--- a/resources/providers/doubaoime/streaming/entry.py
+++ b/resources/providers/doubaoime/streaming/entry.py
@@ -398,7 +398,11 @@ class WebSocketClient:
 
         if self.scheme == "wss":
             context = ssl.create_default_context()
+            try:
             sock = context.wrap_socket(raw_sock, server_hostname=self.host)
+            except Exception:
+                raw_sock.close()
+                raise
         else:
             sock = raw_sock
 
@@ -420,10 +424,13 @@ class WebSocketClient:
         for name, value in self.headers.items():
             lines.append(f"{name}: {value}")
         request = "\r\n".join(lines) + "\r\n\r\n"
+        try:
         sock.sendall(request.encode("utf-8"))
-
         response = self._read_http_response(sock)
         self._validate_handshake(response, key)
+        except Exception:
+            sock.close()
+            raise
         return sock
 
     def _read_http_response(self, sock: socket.socket) -> bytes:

--- a/resources/providers/doubaoime/streaming/entry.py
+++ b/resources/providers/doubaoime/streaming/entry.py
@@ -35,6 +35,7 @@ DEFAULT_CREDENTIAL_PATH = "~/.cache/vinput/doubaoime-asr/credentials.json"
 GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 EXIT_RUNTIME_ERROR = 1
 EXIT_USAGE_ERROR = 2
+CONCURRENCY_QUOTA_STATUS_CODE = 40200011
 
 USER_AGENT = (
     "com.bytedance.android.doubaoime/100102018 "
@@ -264,6 +265,7 @@ class DeviceCredentials:
 class SessionState:
     session_started: bool = False
     error: Optional[str] = None
+    error_code: int = 0
     closed: bool = False
     finished: bool = False
     committed_text: str = ""
@@ -898,8 +900,11 @@ def ensure_healthy_credentials(timeout: int, max_attempts: int = 5) -> DeviceCre
     )
 
 
-def _invalidate_credentials_after_route_failure(message: str) -> None:
-    if _credentials_pinned_by_env() or "service discovery failure" not in message.lower():
+def _invalidate_credentials_after_route_failure(state: SessionState) -> None:
+    if _credentials_pinned_by_env() or not (
+        state.error_code == CONCURRENCY_QUOTA_STATUS_CODE
+        or "service discovery failure" in (state.error or "").lower()
+    ):
         return
     try:
         _resolve_credential_path().unlink()
@@ -1122,6 +1127,7 @@ def handle_server_message(message: bytes, state: SessionState, request_id: str) 
             state.finished = True
             return
         state.error = error_message
+        state.error_code = parsed["status_code"]
         write_stdout({"type": "error", "message": error_message})
         state.finished = True
         return
@@ -1213,6 +1219,9 @@ def run() -> int:
 
     state = SessionState()
     handle_server_message(start_task_response, state, request_id)
+    if state.error:
+        _invalidate_credentials_after_route_failure(state)
+        return EXIT_RUNTIME_ERROR
 
     client.send_binary(
         build_start_session(request_id, token, build_session_config(credentials.device_id))
@@ -1222,7 +1231,7 @@ def run() -> int:
         raise RuntimeError("Doubao IME websocket closed before session start.")
     handle_server_message(start_session_response, state, request_id)
     if state.error:
-        _invalidate_credentials_after_route_failure(state.error)
+        _invalidate_credentials_after_route_failure(state)
         return EXIT_RUNTIME_ERROR
 
     stop_event = threading.Event()
@@ -1358,7 +1367,7 @@ def run() -> int:
             state.closed = True
 
     if state.error:
-        _invalidate_credentials_after_route_failure(state.error)
+        _invalidate_credentials_after_route_failure(state)
         return EXIT_RUNTIME_ERROR
     return 0
 

--- a/resources/providers/doubaoime/streaming/entry.py
+++ b/resources/providers/doubaoime/streaming/entry.py
@@ -770,7 +770,7 @@ def ensure_credentials(timeout: int) -> DeviceCredentials:
         credentials.cdid = generate_uuid()
     if env_token:
         credentials.token = env_token
-    else:
+    elif not credentials.token:
         credentials.token = get_asr_token(credentials.device_id, credentials.cdid, timeout)
 
     save_credentials(credential_path, credentials)

--- a/resources/providers/doubaoime/streaming/entry.py
+++ b/resources/providers/doubaoime/streaming/entry.py
@@ -1349,11 +1349,15 @@ def run() -> int:
                 break
 
             if event_type == "cancel":
-                stop_event.set()
                 break
 
             raise ValueError(f"Unsupported event type: {event_type or '<missing>'}")
     finally:
+        if state.session_started and not state.finished:
+            try:
+                finish_session()
+            except Exception:
+                pass
         if finish_requested and not stop_event.is_set():
             thread.join(timeout=finish_grace_secs)
         stop_event.set()


### PR DESCRIPTION
本 PR 进一步修复了几个稳定性问题，包括：

- 目前每次启动识别，都会重新获取 Credential tokens。容易造成风控；
- 即使语音识别被取消或出错，也应该发送 `finishSession` 事件，否则在服务器那边会认为这个语音会话还 open 着。导致一段时间后活跃会话数过多，开始报错 "concurrency quota exceeded"；
- 一些错误分支里没有 close Websocket，造成连接半断开。